### PR TITLE
Fix typo in MARI filename prefix

### DIFF
--- a/MARI/reduce.py
+++ b/MARI/reduce.py
@@ -104,7 +104,7 @@ remove_bkg = True
 
 # Find all the files in the archive
 def find_file_in_archive(runno):
-    return requests.get(f"http://data.isis.rl.ac.uk/where.py/unixdir?name=MARI{runno}").text.strip("\n") + f"/MARI{runno}.nxs"
+    return requests.get(f"http://data.isis.rl.ac.uk/where.py/unixdir?name=MARI{runno}").text.strip("\n") + f"/MAR{runno}.nxs"
 if isinstance(runno, list):
     new_runnos = []
     for ii in runno:


### PR DESCRIPTION
Closes # <!-- Issue # here -->

## Description

Due to some issues with accessing the archive on the runners, we need to put the full path to the data file into the reduction script. Unfortunately, there's a typo in the current code - for all TS1 instruments, the data filename has just the first three letters of the instrument as a prefix - e.g. for MARI it is `MAR#####.nxs` not `MARI#####.nxs`. Only TS2 instruments have full instrument names, e.g. `INTER#########.nxs`.

What this means is that the reduction code which detects whether the input `runno` is a file or not finds that it is _not_ a file and passes the full path to the Mantid `Load` algorithm. `Load` is "smart" and determines that the input contains a full path and adds this path to its search tree. It also sees that there is possibly a run number and extracts that and prefixes it with the correct three letter prefix. Thus it can load the file despite the wrong name, but it then keeps the full path in the workspace name. As the workspace name is then used to in the output file name, the `/` in the workspace name is added to the output path which points to a sub-directory which does not exist giving the error.

----

An alternative work-around is to just add the archive path to the Mantid search list and to use the run number as a number as before:

```diff
diff --git a/MARI/reduce.py b/MARI/reduce.py
index ed45c6f..94aa4bb 100644
--- a/MARI/reduce.py
+++ b/MARI/reduce.py
@@ -102,18 +102,8 @@ sam_rmm = 0
 # Set to true to remove the constant ToF background from the data.
 remove_bkg = True
 
-# Find all the files in the archive
-def find_file_in_archive(runno):
-    return requests.get(f"http://data.isis.rl.ac.uk/where.py/unixdir?name=MARI{runno}").text.strip("\n") + f"/MAR{runno}.nxs"
-if isinstance(runno, list):
-    new_runnos = []
-    for ii in runno:
-        new_runnos.append(find_file_in_archive(ii))
-    runno = new_runnos
-else:
-    runno = find_file_in_archive(runno)
-
-print(f"found filepath: {runno}")
+# Adds archive path to Mantid search list
+config.appendDataSearchDir(requests.get(f"http://data.isis.rl.ac.uk/where.py/unixdir?name=MARI{runno}").text.strip("\n"))
 
 # This is the main reduction call made in the script
 output_ws = iliad_mari(runno=runno, ei=ei, wbvan=wbvan, monovan=monovan, sam_mass=sam_mass, sum_runs=sum_runs,
```