### PR TITLE
Update reduce.py

### DIFF
--- a/VESUVIO/reduce.py
+++ b/VESUVIO/reduce.py
@@ -75,7 +75,7 @@ file_name = (
     requests.get(
         f"http://data.isis.rl.ac.uk/where.py/unixdir?name=VESUVIO{runno}"
     ).text.strip("\n")
-    + f"/VESUVIO000{runno}.raw"
+    + f"/VESUVIO000{runno}"
 )
 
 print(f"Starting with file: {file_name}")


### PR DESCRIPTION
> Possible fixes:
On line 78 of your script remove .raw in the string of the run number. The idea is that by using a nexus files for the runs, the same bug will happen for the run workspace, and then they will be successfully subtracted becausae they are both nexus. What causes the issue is whne you subtract a nexus from a raw or vice-versa. This might give a different error because I remember we did this to patch up the issues that IDAaaS was having with finding files.